### PR TITLE
Fix version file URL field

### DIFF
--- a/StorkDeliverySystem.version
+++ b/StorkDeliverySystem.version
@@ -1,14 +1,14 @@
 {
 	"NAME":           "Stork Delivery System by Kermangeddon Industries (SDS)",
-	"URL":            "https://github.com/zer0Kerbal/KGEx/StorkDeliverySystem/StorkDeliverySystem.version",
+	"URL":            "https://github.com/zer0Kerbal/StorkDeliverySystem/raw/master/StorkDeliverySystem.version",
 	"DOWNLOAD":       "http://github.com/zer0Kerbal/StorkDeliverySystem/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/StorkDeliverySystem/Changelog.cfg",
-    "GITHUB":
-    {
-        "USERNAME":          "zer0Kerbal",
-        "REPOSITORY":        "StorkDeliverySystem",
-        "ALLOW_PRE_RELEASE": false
-    },
+	"GITHUB":
+	{
+		"USERNAME":          "zer0Kerbal",
+		"REPOSITORY":        "StorkDeliverySystem",
+		"ALLOW_PRE_RELEASE": false
+	},
 	"VERSION":
 	{
 		"MAJOR": 0,


### PR DESCRIPTION
The current URL field is a 404. It should link to an online copy of the version file.
Found while processing KSP-CKAN/NetKAN#7735.

Tagging @zer0Kerbal since not everyone has notifications turned on for pull requests.